### PR TITLE
[FEAT] Shadow Drive utility methods/ProfileDataProvider

### DIFF
--- a/src/hooks/profileDataProvider.tsx
+++ b/src/hooks/profileDataProvider.tsx
@@ -1,0 +1,52 @@
+import { FC } from 'react';
+import { ProfileViewModel } from '~/viewmodels/Profile/ProfileViewModel';
+import { WalletModel } from '~/models/Wallet/WalletModel';
+import { GumNameService, useGumContext } from '@gumhq/react-sdk';
+import { useShadowDrive } from '~/hooks/useShadowDrive';
+import { useAnchorWallet, useConnection, useWallet } from '@solana/wallet-adapter-react';
+import { useViewModel } from '../../reactReactive/viewmodels/useViewModel';
+
+interface SessionProviderProps {
+  children: React.ReactNode;
+}
+
+const ProfileDataProvider: FC<SessionProviderProps> = ({ children }) => {
+  const profileVM = useViewModel<ProfileViewModel>(ProfileViewModel);
+  const walletVM = useViewModel<WalletModel>(WalletModel);
+  const { sdk } = useGumContext();
+  const { getFilesFromStorage } = useShadowDrive();
+  const anchorWallet = useAnchorWallet();
+  const basicWallet = useWallet();
+  const connection = useConnection();
+  const gum = new GumNameService(sdk);
+
+  const verifyDomain = async () => {
+    const domainName = await gum
+      .getNameservicesByAuthority(walletVM.wallet)
+      .then((data) => data.map((domainData) => domainData.name));
+    const removedName = domainName.at(0);
+    if (domainName.length != 0) {
+      profileVM.verifyDomainName(true);
+      profileVM.setDomainName(removedName!);
+      console.log('domain name found');
+    } else {
+      console.log('no domain name found');
+    }
+  };
+
+  const verifyStorage = async (): Promise<void> => {
+    await getFilesFromStorage(
+      connection.connection,
+      anchorWallet,
+      `${profileVM.domainName}_Character_Data.json`
+    );
+  };
+
+  if (basicWallet.connected) {
+    verifyDomain().then();
+    verifyStorage().then();
+  }
+  return <div>{children}</div>;
+};
+
+export default ProfileDataProvider;

--- a/src/hooks/useShadowDrive.tsx
+++ b/src/hooks/useShadowDrive.tsx
@@ -57,11 +57,15 @@ export const useShadowDrive = () => {
     }
   };
 
-  const getFilesFromWorldStorage = async (
+  /*
+   * - Filename is the name of the document stored on the storage account
+   * */
+  const getFilesFromStorage = async (
     connection: Connection,
-    wallet: AnchorWallet | undefined
+    wallet: any,
+    fileName: string
   ): Promise<string[]> => {
-    let files: string[] = [];
+    const files: string[] = [];
     try {
       // via the Mercury API, get all ShadowFiles from storage
       const shdwDrive = await new ShdwDrive(connection, wallet).init();
@@ -71,11 +75,22 @@ export const useShadowDrive = () => {
       const storageAcctKey = storageAcct.storage_account;
       const storageFiles = await shdwDrive.listObjects(new PublicKey(storageAcctKey));
       console.log('stored objects: ', storageFiles.keys);
-      files = storageFiles.keys;
+
+      if (storageFiles.keys.includes(fileName)) {
+        // TODO: create a StorageModel to store a users shdw acct data
+        files.push(fileName);
+        await buildShadowUrl(String(storageAcctKey), fileName);
+      } else {
+        console.log(`${fileName} file not found`);
+      }
     } catch (error) {
       console.log('get files error: ', error);
     }
     return files;
+  };
+
+  const buildShadowUrl = async (storageAccountKey: string, fileName: string): Promise<string> => {
+    return `https://shdw-drive.genesysgo.net/${storageAccountKey}/${fileName}`;
   };
 
   // const editInventoryShdwFile = async (connection: Connection, wallet: any): Promise<void> => {
@@ -89,5 +104,5 @@ export const useShadowDrive = () => {
   //   }
   // };
 
-  return { createStorageAccount, uploadCharacterFiles, getFilesFromWorldStorage };
+  return { createStorageAccount, uploadCharacterFiles, getFilesFromStorage, buildShadowUrl };
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -16,6 +16,7 @@ import GumSessionProvider from '~/components/SessionProvider/GumSessionProvider'
 
 import { mercuryApi } from '~/utils/api';
 import '~/styles/globals.css';
+import ProfileDataProvider from '~/hooks/profileDataProvider';
 
 require('@solana/wallet-adapter-react-ui/styles.css');
 
@@ -34,7 +35,9 @@ const TextGameApp: AppType<{ session: Session | null }> = ({
       <UseGumSDKProvider>
         <SessionProvider session={session}>
           <GumSessionProvider>
-            <Component {...pageProps} />
+            <ProfileDataProvider>
+              <Component {...pageProps} />
+            </ProfileDataProvider>
           </GumSessionProvider>
         </SessionProvider>
       </UseGumSDKProvider>

--- a/src/views/Profile/ProfileView.tsx
+++ b/src/views/Profile/ProfileView.tsx
@@ -6,7 +6,6 @@ import { LandingHeaderView } from '~/views/Landing/LandingHeader/LandingHeaderVi
 import { LandingSidebarView } from '~/views/Landing/LandingSidebar/Sidebar';
 import { ProfileViewModel } from '~/viewmodels/Profile/ProfileViewModel';
 import { observer } from 'mobx-react-lite';
-import { WalletModel } from '~/models/Wallet/WalletModel';
 import { CharacterCreationViewModel } from '~/viewmodels/CharacterCreation/CharacterCreationViewModel';
 import { useShadowDrive } from '~/hooks/useShadowDrive';
 import { CharacterCreationView } from '~/views/CharacterCreation/CharacterCreationView';
@@ -14,32 +13,12 @@ import { useViewModel } from '../../../reactReactive/viewmodels/useViewModel';
 
 export const ProfileView = observer((): JSX.Element => {
   const profileVM = useViewModel<ProfileViewModel>(ProfileViewModel);
-  const walletVM = useViewModel<WalletModel>(WalletModel);
   const characterVM = useViewModel<CharacterCreationViewModel>(CharacterCreationViewModel);
   const connection = useConnection();
   const walletSet = useAnchorWallet();
   const walletConnect = useWallet();
   const { sdk } = useGumContext();
   const { uploadCharacterFiles } = useShadowDrive();
-  const gum = new GumNameService(sdk);
-
-  const verifyDomain = async () => {
-    const domainName = await gum
-      .getNameservicesByAuthority(walletVM.wallet)
-      .then((data) => data.map((domainData) => domainData.name));
-    const removedName = domainName.at(0);
-    if (domainName.length != 0) {
-      profileVM.verifyDomainName(true);
-      profileVM.setDomainName(removedName!);
-      console.log('domain name found');
-    } else {
-      console.log('no domain name found');
-    }
-  };
-
-  if (walletConnect.connected) {
-    verifyDomain().then();
-  }
 
   return (
     <div className="antialiased bg-gradient-to-b from-[#151B25] to-[#000000] dark:bg-gray-900">


### PR DESCRIPTION
Removed profile/gum verification logic to a higher app level instead of being in the ProfileView, when that logic will be needed across multiple Pages. Found a non-app-crashing bug that was fixed. Will need to move MusicPlayer logic to an app level provider as well in the future. May also need a ProfileModel. Profile data doesn't appear to load properly when hard reloaded on Profile page.